### PR TITLE
feat: '/api/service'の基本的なapiを実装

### DIFF
--- a/xiaovy.tvapp.web/src/app/api/service/call/episode/route.ts
+++ b/xiaovy.tvapp.web/src/app/api/service/call/episode/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// GET /api/service/call/episode?episodeId=xxxx&platformUid=xxxx&platformToken=xxxx
+export async function GET(request: NextRequest) {
+    const { searchParams } = new URL(request.url);
+    const episodeId = searchParams.get('episodeId');
+    const platformUid = searchParams.get('platformUid');
+    const platformToken = searchParams.get('platformToken');
+
+    if (!episodeId || !platformUid || !platformToken) {
+        return NextResponse.json({ error: 'episodeId, platformUid, platformToken が必須です。' }, { status: 400 });
+    }
+
+    try {
+        const response = await fetch(
+            `https://platform-api.tver.jp/service/api/v1/callEpisode/${episodeId}?platform_uid=${platformUid}&platform_token=${platformToken}`,
+            {
+                headers: {
+                    'x-tver-platform-type': 'web',
+                    'Origin': 'https://tver.jp',
+                    'Referer': 'https://tver.jp/',
+                },
+            }
+        );
+
+        if (!response.ok) {
+            return NextResponse.json({ error: 'Failed to retrieve callEpisode results' }, { status: response.status });
+        }
+
+        const data = await response.json();
+        return NextResponse.json({ data });
+    } catch (error) {
+        console.error("Error:", error);
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+    }
+}

--- a/xiaovy.tvapp.web/src/app/api/service/call/home/route.ts
+++ b/xiaovy.tvapp.web/src/app/api/service/call/home/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// GET /api/service/call/home?platformUid=xxxx&platformToken=xxxx
+export async function GET(request: NextRequest) {
+    const { searchParams } = new URL(request.url);
+    const platformUid = searchParams.get('platformUid');
+    const platformToken = searchParams.get('platformToken');
+
+    if (!platformUid || !platformToken) {
+        return NextResponse.json({ error: 'platformUid, platformToken が必須です。' }, { status: 400 });
+    }
+
+    try {
+        const response = await fetch(
+            `https://platform-api.tver.jp/service/api/v1/callHome?platform_uid=${platformUid}&platform_token=${platformToken}`,
+            {
+                headers: {
+                    'x-tver-platform-type': 'web',
+                    'Origin': 'https://tver.jp',
+                    'Referer': 'https://tver.jp/',
+                },
+            }
+        );
+
+        if (!response.ok) {
+            return NextResponse.json({ error: 'Failed to retrieve call results' }, { status: response.status });
+        }
+
+        const data = await response.json();
+        return NextResponse.json({ data });
+    } catch (error) {
+        console.error("Error:", error);
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+    }
+}

--- a/xiaovy.tvapp.web/src/app/api/service/call/ranking/episode/detail/[genre]/route.ts
+++ b/xiaovy.tvapp.web/src/app/api/service/call/ranking/episode/detail/[genre]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// GET /api/service/call/ranking/episode/detail/[genre]
+export async function GET(request: NextRequest, { params }: { params: { genre: string } }) {
+    const { genre } = params;
+
+    if (!genre || genre.trim() === '') {
+        return NextResponse.json({ error: 'Genre が必須です。' }, { status: 400 });
+    }
+
+    try {
+        const response = await fetch(
+            `https://service-api.tver.jp/api/v1/callEpisodeRankingDetail/${genre}`,
+            {
+                headers: {
+                    'x-tver-platform-type': 'web',
+                    'Origin': 'https://tver.jp',
+                    'Referer': 'https://tver.jp/',
+                },
+            }
+        );
+
+        if (!response.ok) {
+            return NextResponse.json({ error: 'Failed to retrieve ranking details' }, { status: response.status });
+        }
+
+        const data = await response.json();
+        return NextResponse.json({ data });
+    } catch (error) {
+        console.error("Error:", error);
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+    }
+}

--- a/xiaovy.tvapp.web/src/app/api/service/call/streaminglink/route.ts
+++ b/xiaovy.tvapp.web/src/app/api/service/call/streaminglink/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// GET /api/service/call/streaminglink?episodeId=xxxx
+
+// Response
+// {
+//     "video_url": "https://sample"
+// }
+export async function GET(request: NextRequest) {
+    const { searchParams } = new URL(request.url);
+    const episodeId = searchParams.get('episodeId');
+    const functionHost = process.env.AZURE_FUNCTION_STREEAMING;
+    const key = process.env.AZURE_FUNCTION_STREEAMING_CODE_KEY;
+
+    if (!episodeId || episodeId.trim() === '') {
+        return NextResponse.json({ error: 'episodeId が必須です。' }, { status: 400 });
+    }
+
+    try {
+        const response = await fetch(
+            `${functionHost}/api/http_trigger?code=${key}&url=https://tver.jp/episodes/${episodeId}`,
+            {
+                headers: {
+                    'x-tver-platform-type': 'web',
+                    'Origin': 'https://tver.jp',
+                    'Referer': 'https://tver.jp/',
+                },
+            }
+        );
+
+        if (!response.ok) {
+            return NextResponse.json({ error: 'Failed to retrieve callEpisode results' }, { status: response.status });
+        }
+
+        const data = await response.json();
+        return NextResponse.json(data);
+    } catch (error) {
+        console.error("Error:", error);
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+    }
+}

--- a/xiaovy.tvapp.web/src/app/api/service/search/route.ts
+++ b/xiaovy.tvapp.web/src/app/api/service/search/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// GET /api/service/search?keyword=xxx&platformUid=xxx&platformToken=xxx
+export async function GET(req: NextRequest) {
+    const { searchParams } = new URL(req.url);
+    const keyword = searchParams.get('keyword');
+    const platformUid = searchParams.get('platformUid');
+    const platformToken = searchParams.get('platformToken');
+
+    if (!keyword || !platformUid || !platformToken) {
+    return NextResponse.json({ error: 'Keyword, platformUid, platformToken が必須です。' }, { status: 400 });
+    }
+
+    try {
+        const response = await fetch(
+            `https://platform-api.tver.jp/service/api/v1/callKeywordSearch?platform_uid=${platformUid}&platform_token=${platformToken}&keyword=${keyword}`,
+            {
+            headers: {
+                'x-tver-platform-type': 'web',
+                'Origin': 'https://tver.jp',
+                'Referer': 'https://tver.jp/',
+            },
+            }
+        );
+
+        if (!response.ok) {
+            return NextResponse.json({ error: 'Failed to retrieve search results' }, { status: response.status });
+        }
+
+        const data = await response.json();
+        return NextResponse.json({ data });
+    } catch (error) {
+        console.error("Error:", error); 
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+    }
+}

--- a/xiaovy.tvapp.web/src/app/api/service/session/route.ts
+++ b/xiaovy.tvapp.web/src/app/api/service/session/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+type SessionToken = {
+    platformUid: string;
+    platformToken: string;
+};
+
+// POST /api/service/session
+export async function POST() {
+    try {
+        const response = await fetch(
+            'https://platform-api.tver.jp/v2/api/platform_users/browser/create',
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'Origin': 'https://s.tver.jp',
+                    'Referer': 'https://s.tver.jp/',
+                },
+                body: 'device_type=pc'
+            }
+        );
+
+        if (!response.ok) {
+            return NextResponse.json({ error: 'sessionTokenの取得に失敗しました。' }, { status: response.status });
+        }
+
+        const jsonResponse = await response.json();
+
+        const sessionToken: SessionToken = {
+            platformUid: jsonResponse.result.platform_uid,
+            platformToken: jsonResponse.result.platform_token,
+        };
+
+        return NextResponse.json(sessionToken);
+    } catch (error) {
+        console.error("Error:", error);
+        return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+    }
+}


### PR DESCRIPTION
## /api/service
[GET] 
```
/api/service/call/home?platformUid=xxxx&platformToken=xxxx
/api/service/call/streaminglink?episodeId=xxxx
/api/service/call/ranking/episode/detail/[genre]
/api/service/call/episode?episodeId=xxxx&platformUid=xxxx&platformToken=xxxx
/api/service/search?keyword=xxx&platformUid=xxx&platformToken=xxx
```

[POST]
```
/api/service/session
```